### PR TITLE
Fix error (nunjucks is not a function) And Prevent reload page if filename is not .html or .njk

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,15 @@
   "name": "vite-plugin-nunjucks",
   "version": "0.1.10",
   "description": "Vite plugin for Nunjucks",
+  "type": "module",
   "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs"
+    }
+  },
   "author": "Jax-p",
   "license": "MIT",
   "private": false,

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "vite-plugin-nunjucks",
   "version": "0.1.10",
   "description": "Vite plugin for Nunjucks",
-  "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "exports": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,7 @@ export default (options: nunjucksPluginOptions = {}): Plugin => {
     function handleHotUpdate(context: HmrContext): void|[] {
         const filename = path.resolve(context.file)
         if (!filename.startsWith(options.templatesDir)) return;
+        if (!filename.endsWith('.html') && !filename.endsWith('.njk')) return;
         console.info(`Template file ${path.basename(filename)} has been changed. Sending full-reload.`);
         context.server.ws.send({type: 'full-reload'});
         return []

--- a/test.js
+++ b/test.js
@@ -1,5 +1,5 @@
 const nunjucks = require("nunjucks");
-const nunjucksPlugin = require('./dist/index.cjs').default;
+const nunjucksPlugin = require('./dist').default;
 
 test('it can create plugin without options', () => {
     const plugin = nunjucksPlugin();

--- a/test.js
+++ b/test.js
@@ -1,5 +1,5 @@
 const nunjucks = require("nunjucks");
-const nunjucksPlugin = require('./dist').default;
+const nunjucksPlugin = require('./dist/index.cjs').default;
 
 test('it can create plugin without options', () => {
     const plugin = nunjucksPlugin();


### PR DESCRIPTION
This Pr fix this issue https://github.com/Jax-p/vite-plugin-nunjucks/issues/12

And Added check to prevent page reload in **Options** **templatesDir** if filename is not .html or .njk