### PR TITLE
[FIX] Variables per each entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 
 [Vite](https://github.com/vitejs/vite) plugin for [Nunjucks](https://github.com/mozilla/nunjucks).
 
-Supports:    
-📂 - [Templates and layouts](https://mozilla.github.io/nunjucks/templating.html) 🔗     
-📃 - Variables for each entry point (HTML) and global scope    
+Supports:
+📂 - [Templates and layouts](https://mozilla.github.io/nunjucks/templating.html) 🔗
+📃 - Variables for each entry point (HTML) and global scope
 🎠 - [Custom filters](https://mozilla.github.io/nunjucks/api.html#custom-filters) 🔗 and [extensions](https://mozilla.github.io/nunjucks/api.html#custom-tags) 🔗
 
 ## Install
@@ -84,7 +84,7 @@ export default {
 ```
 
 ## Environment
-Since v0.1.4 you can pass [custom filters](https://mozilla.github.io/nunjucks/api.html#custom-filters) and [extensions](https://mozilla.github.io/nunjucks/api.html#custom-tags) to the environment.   
+Since v0.1.4 you can pass [custom filters](https://mozilla.github.io/nunjucks/api.html#custom-filters) and [extensions](https://mozilla.github.io/nunjucks/api.html#custom-tags) to the environment.
 Config example:
 ```JavaScript
 import nunjucks from 'vite-plugin-nunjucks'
@@ -178,6 +178,7 @@ export default {
 | Parameter | Type  | Default | Description |
 | ----------- | ----------- | ----------- | ----------- |
 | templatesDir | `string` | `./src/html` | Absolute path where are HTML templates located. Example: `path.resolve(process.cwd(), 'src', 'myTemplates')`
+| useContextPathKey | `boolean` | `false` | If `true` entry point keys use path . Example `{ '/index.html': {active:'Home'}, '/about/index.html': {active: 'About'} }`
 | variables | `Record<string, object>` | `{}` | Variables for each entry point. Example `{ 'index.html': {username:'John'} }`
 | nunjucksConfigure | `nunjucks.ConfigureOptions` | `{noCache:true}` | [Configure options for Nunjucks](https://mozilla.github.io/nunjucks/api.html#configure)
 | nunjucksEnvironment | `nunjucksEnvironmentOptions OR nunjucks.Environment` | `{noCache:true}` | Configure Nunjucks environment or pass your own env

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,7 @@ export default (options: nunjucksPluginOptions = {}): Plugin => {
     }
 
     function handleTransformHtml(html: string, context: IndexHtmlTransformContext): IndexHtmlTransformResult | void | Promise<IndexHtmlTransformResult | void> {
-        const key = path.basename(context.path);
+        const key = options.useContextPathKey ? context.path : path.basename(context.path);
         const globalVariables = options.variables?.[globalVariablesKey] || {};
         const templateVariables = options.variables?.[key] || {};
         return new Promise((resolve, reject) => {
@@ -48,7 +48,7 @@ export default (options: nunjucksPluginOptions = {}): Plugin => {
                 } else {
                     resolve(res);
                 }
-            });    
+            });
         });
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@ export type templateVariables = Record<string, object>
 export interface nunjucksPluginOptions {
     templatesDir?: string,
     variables?: templateVariables,
+    useContextPathKey?: boolean,
     nunjucksConfigure?: ConfigureOptions,
     nunjucksEnvironment?: nunjucksEnvironmentOptions | Environment
 }


### PR DESCRIPTION
This PR fixes #7 by adding a new configuration option, `useContextPathKey`, so that we can specify different variables per route.

Configuration example:

```ts
export default defineConfig({
  build,
  plugins: [
    nunjucks({
      templatesDir: resolve(__dirname, "."),
      useContextPathKeys: true,
      variables: {
        "*": {data},
        "/index.html": {
          active: "Home",
        },
        '/login/index.html': {
          active: "Login"
        },
        '/dashboard/index.html': {
            active: "Dashboard",
        }
      },
    }),
  ],
  server: {
    host: true,
    port: 5173, // change port number if you prefer
  },
});
```